### PR TITLE
add link to mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See our [launch plan][1] for more info.
 
 ## Join our Mailing List
 
-UNDER CONSTRUCTION
+This CHAOSS working group is using the general [CHAOSS mailing list](https://lists.linuxfoundation.org/mailman/listinfo/chaoss).
 
 ## Background
 


### PR DESCRIPTION
I suggest we use the CHAOSS mailing list until there is a demonstrated need to have a separate mailing list.

Our experience in CHAOSS is that it is easier to coordinate working groups if we all work on the same mailing list. In fact, we have abandoned working-group specific mailing lists because people did not sign up to them and it was difficult for new members to find the right mailing list. 