### PR TITLE
link to focus area labor investment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ significance and industry norms.
 
 | Focus Area | Goal |
 | --- | --- |
-| 1. Labor Investment | Estimating the labor investment in open source projects. |
+| 1. [Labor Investment](./focus-areas/labor-investment) | Estimating the labor investment in open source projects. |
 | 2. Innovation Value | Evaluating open source project development for comparing with in-house and outsourcing options. |
 | 3. Downstream Value | Estimate the value provided to other open source projects. |
 | 4. Ecosystem Value | Estimating the value of an open source project’s ecosystem. |

--- a/focus-areas/README.md
+++ b/focus-areas/README.md
@@ -2,7 +2,7 @@
 
 | Focus Area | Goal |
 | --- | --- |
-| 1. Labor Investment | Estimating the labor investment in open source projects. |
+| 1. [Labor Investment](./labor-investment) | Estimating the labor investment in open source projects. |
 | 2. Innovation Value | Evaluating open source project development for comparing with in-house and outsourcing options. |
 | 3. Downstream Value | Estimate the value provided to other open source projects. |
 | 4. Ecosystem Value | Estimating the value of an open source project’s ecosystem. |


### PR DESCRIPTION
This pr adds a link to the labor investment focus area in the tables in the main readme and in the focus-area folder.