### PR TITLE
Fix formatting of organizational-influence.md

### DIFF
--- a/focus-areas/organizational-value/organizational-influence.md
+++ b/focus-areas/organizational-value/organizational-influence.md
@@ -3,11 +3,20 @@
 # Organizational Influence
 
 Question: How much influence does an organization have on an open source community?
+
+
 ## Description
+
 Organizational Influence is a measure of the influence that an organization has on an open source community. Organizations, which are often larger enterprise corporations, may influence the direction of a project, signaling some level of control within a community. This equates to the level of influence an organization has over the development trajectory of an open source project that it contributes to and has a vested interest in.
- ## Objectives
+
+
+## Objectives
+
 Organizations can have influence in open source communities. The measure of organizational influence can be enlightening on its own or serve as an opportunity to show growth in organizational influence over time. This metric can help an open source advocate in an organization justify continued funding and support for engagement. This metric can also help open source maintainers track and measure organizational influence to add legitimacy to their project, and monitor the level of control by individual organizations. Organizational influence may also serve as a signal of how easy or difficult it may be for new members to contribute to an open source project. 
+
+
 ## Implementation
+
 Some specific examples to consider when measuring organizational influence include: 
 
 * How many organizational members are contributing to a project - [contributors](https://chaoss.community/metric-contributors/)
@@ -18,18 +27,14 @@ Some specific examples to consider when measuring organizational influence inclu
 * Organizational members in project maintainer roles 
 * Organizations sponsoring an open source project
 
-## Visualizations
 
 ### Tools Providing the Metric
 
 * Augur
 * GrimoireLab
 
-### Data Collection Strategies
-
-## References
-
 ## Contributors
+
 * Sean Goggins
 * Matt Germonprez
 * Vinod Ahuja


### PR DESCRIPTION
The format of the metric was not following the standard 
needed for the automatic metric release. Empty sections
needed to be removed.


Signed-off-by: Georg J.P. Link <linkgeorg@gmail.com>