### PR TITLE
Update readme to align w/ OSPO narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CHAOSS Value Working Group
+# OSPO Metrics Working Group
 
 ## Table of Contents
 
@@ -7,17 +7,40 @@
 - [Contributing](#contributing)
 - [Metrics](#metrics)
 - [Contributors](#contributors)
+- [Acknoledgements](#Acknoledgements)
 - [License](#license)
 
 ## Introduction
 
+### Scope
+
+A well-designed Open Source Program Office (OSPO), when present, is the center of competency for an organization’s open source operations and structure. As described in the [OSPO deep dive research report](https://www.linuxfoundation.org/research/a-deep-dive-into-open-source-program-offices), OSPOs benefit organizations worldwide by:
+
+* Implementing unique and flexible sets of tools that support OSS development models while meeting corporate Information Technology guidelines
+* Overseeing the establishment or adaptation of internal policies to better manage open source software (OSS) compliance in fast-moving, dynamic environments
+* Helping to bridge the cultural gap between traditional software development practices and the requirements of open source development
+* Improving technical mentorship, and compliance-related education and training programming for team members across all levels of the organization
+
+> These strategic open source centers can take many shapes. For instance, depending on the size of the organization, its structure can vary from a virtual OSPO with one FTE to a large dedicated team. To learn more, please take a look at the different [structures](https://8112310.fs1.hubspotusercontent-na1.net/hubfs/8112310/LF%20Research/LFR_LFAID_Deep_Dive_Open_Source_Program_Offices_081922.pdf), [roles](https://8112310.fs1.hubspotusercontent-na1.net/hubfs/8112310/LF%20Research/LFR_LFAID_Deep_Dive_Open_Source_Program_Offices_081922.pdf), and [responsibilities](https://8112310.fs1.hubspotusercontent-na1.net/hubfs/8112310/LF%20Research/LFR_LFAID_Deep_Dive_Open_Source_Program_Offices_081922.pdf) an organization can choose when builging an OSPO.
+
+### Problem
+
+Tracking performance metrics is one of the [key responsibilities of many OSPOs](https://ospomindmap.todogroup.org/): [OSPOs might use specialized tools](https://todogroup.org/guides/management-tools/) to track their organization’s contributions to open source projects, analyze the type of contributions from their organization, identify contribution patterns, and provide recommendations to improve the development impact
+
 ### Goals
 
-Community initiatives do not reflect the same value as other common organizational efforts. This results in community work often being undervalued by people, organizations, communities, and society. The Value working group aims to advance how we understand the value that projects can provide. 
+Community initiatives do not reflect the same value as organizational efforts. The OSPO Metrics working group aims to advance how organizations understand the value that open source projects can provide as well as the value of these programs / initiatives.
+
+Main objectives include:
+
+* Define useful metrics
+* Ease implementation with CHAOSS tooling
+* Set up best practices and metrics standards for OSPOs
+
 
 ### Purpose
 
-Value group will develop metrics that, when measured, help make the impact of community work more transparent. 
+OSPO Metrics group will develop metrics that, when measured, help make the impact of community work more transparent. It will also help drive the adoption of metrics, implementation of best practices, and tools to adopt community health metrics standards, which OSPO practitioners can engage and contribute.
 
 ### Who should join this working group?
 
@@ -64,6 +87,7 @@ The translations of these metrics are available at [chaoss/translations](https:/
 
 - [Vinod Ahuja](https://github.com/vinodkahuja)
 - [Sean Goggins](https://github.com/sgoggins)
+- [Ana Jiménez](https://github.com/anajsana)
 
  Please feel free to contact our chairs in case you require any sort of assistance.
 
@@ -73,6 +97,10 @@ We greatly appreciate our contributors at CHAOSS and look forward to your joinin
 
 Are you eligible to be on this list? You are if you helped in any capacity, for example: Filed an issue. Created a Pull Request. Gave feedback on our work. The team will try to update this list regularly, but please open an issue or post
 on the mailing list if we've missed anyone.
+
+## Acknoledgements
+
+CHAOSS OSPO Metrics working group is under the auspices of [TODO Group](https://todogroup.org/#), an open group of OSPO practitioners who aim to create and share knowledge, collaborate on practices and develop tools to run successful and effective Open Source Program Offices.
 
 ## License
 


### PR DESCRIPTION
Part of the CHAOSS/TODO collaboration is to turn this working group into the OSPO Metrics WG. This commit updates its README.md to align with the new OSPO metrics scope and goals.