### PR TITLE
New Metric Template Update: organizational-project-skill-demand.md

### DIFF
--- a/focus-areas/individual-value/organizational-project-skill-demand.md
+++ b/focus-areas/individual-value/organizational-project-skill-demand.md
@@ -1,12 +1,12 @@
 # Organizational Project Skill Demand
 
-Question: How many organizations are using this project and could hire me if I become proficient?
+**Question:** How many organizations are using this project and could hire me if I become proficient?
 
 
-### Overview
+## Overview
 The Organization's Project Skill Demand metric is aimed at determining downstream demand of skills related to an open source project. This metric looks at organizations that deploy a project as part of an IT infrastructure, other open source projects with declared dependencies, and references to the project through social media, conference mentions, blog posts, and similar activities. Tracking this metric helps developers identify promising projects for career growth and contributes to project sustainability by indicating community engagement and potential for future development. While this metric doesn't directly address DEI issues, it can indirectly contribute by highlighting projects with diverse communities and inclusive practices.
 
-### Want to Know More?
+## Want to Know More?
 
 <span markdown="1"><details>
 <summary>Click to read more about this metric.</summary>
@@ -47,7 +47,7 @@ StackOverview publishes an annual developer's survey
 
 </details></span>
 
-### References
+## References
 - [Open Source Sponsors][l1]
 - [Fiscal Sponsors and Open Source][l2]
 - [Large Corporate OpenSource Sponsors][l3]
@@ -64,14 +64,14 @@ StackOverview publishes an annual developer's survey
 [l6]: https://www.thoughtworks.com/radar
 [l7]: https://insights.stackoverflow.com/survey/2019#technology
 
-### Contributors
+## Contributors
 
 * Matt Germonprez
 * Kevin Lumbard
 * Georg Link
 * Peculiar C Umeh
 
-### Additional Information
+## Additional Information
 To edit this metric please [submit a Change Request here]( https://github.com/chaoss/wg-value/blob/main/focus-areas/individual-value/organizational-project-skill-demand.md)
 
 To reference this metric in software or publications please use this stable URL: [https://chaoss.community/?p=3566](https://chaoss.community/?p=3566)

--- a/focus-areas/individual-value/organizational-project-skill-demand.md
+++ b/focus-areas/individual-value/organizational-project-skill-demand.md
@@ -3,32 +3,22 @@
 Question: How many organizations are using this project and could hire me if I become proficient?
 
 
-## Description
-Organizations engage with open source projects through use and dependencies. 
-This metric is aimed at determining downstream demand of skills related to 
-an open source project. This metric looks at organizations that deploy a 
-project as part of an IT infrastructure, other open source projects with 
-declared dependencies, and references to the project through social media, 
-conference mentions, blog posts, and similar activities.
+## Overview
+The Organization's Project Skill Demand metric is aimed at determining downstream demand of skills related to an open source project. This metric looks at organizations that deploy a project as part of an IT infrastructure, other open source projects with declared dependencies, and references to the project through social media, conference mentions, blog posts, and similar activities. Tracking this metric helps developers identify promising projects for career growth and contributes to project sustainability by indicating community engagement and potential for future development. While this metric doesn't directly address DEI issues, it can indirectly contribute by highlighting projects with diverse communities and inclusive practices.
 
-## Objectives
-As a developer, I'd like to invest my skills and time in a project that has a
-likelihood of getting me a decent paying job in the future. People can use the
-Downstream Organizational Impact of a Project Software metric to discover which
-projects are used by organizations, and they may, therefore, be able to pursue
-job opportunities with, possibly requiring IT support services.
+## Want to Know More?
 
-## Implementation
+<span markdown="1"><details>
+<summary>Click to read more about this metric.</summary>
 
-Base metrics include:
-- Number of organizations that created issues for a project
-- Number of organizations that created pull requests for a project
-- Number of organizations that blog or tweet about a project
-- Number of organizations that mention a project in open hiring requests
-- Number of organizations that are represented at meetups about this project
-- Number of other projects that are dependent on a project
-- Number of books about a project
+### Data Collection Strategies 
 - Google search trends for a project
+
+### Filters 
+- Google Trends - for showing search interest over time
+- ThoughtWorks TechRadar - project assessments from a tech consultancy
+- StackOverflow Developers Survey - annual project rankings
+- Augur
 
 ### Visualizations
 
@@ -55,14 +45,7 @@ StackOverview publishes an annual developer's survey
 
 ![StackOverflow](https://github.com/chaoss/wg-value/blob/main/focus-areas/individual-value/images/organizational-project-skill-demand_stack-overflow.png)
 
-### Tools Providing the Metric
-* Google Trends - for showing search interest over time
-* ThoughtWorks TechRadar - project assessments from a tech consultancy
-* StackOverflow Developer's Survey - annual project rankings
-* Augur; Examples are available for multiple repositories:
-  - [Rails](http://augur.osshealth.io/repo/Rails%20(wg-value)/rails/overview)
-  - [Zephyr](http://augur.osshealth.io/repo/Zephyr-RTOS/zephyr/overview)
-  - [CloudStack](http://augur.osshealth.io/repo/Apache%20(wg-value)/cloudstack/overview)
+</details></span>
 
 ## References
 - [Open Source Sponsors][l1]
@@ -80,3 +63,21 @@ StackOverview publishes an annual developer's survey
 [l5]: https://aisel.aisnet.org/cgi/viewcontent.cgi?article=1496&context=amcis2018
 [l6]: https://www.thoughtworks.com/radar
 [l7]: https://insights.stackoverflow.com/survey/2019#technology
+
+## Contributors
+
+* Matt Germonprez
+* Kevin Lumbard
+* Georg Link
+* Peculiar C Umeh
+
+## Additional Information
+To edit this metric please [submit a Change Request here]( https://github.com/chaoss/wg-value/blob/main/focus-areas/individual-value/organizational-project-skill-demand.md)
+To reference this metric in software or publications please use this stable URL: [https://chaoss.community/?p=3566](https://chaoss.community/?p=3566)
+
+<!-- # For groupings in the knowledge base
+Context tags: Organization, Contributor, Ecosystem
+Keyword tags: demanded skills, companies, organization
+-->
+
+

--- a/focus-areas/individual-value/organizational-project-skill-demand.md
+++ b/focus-areas/individual-value/organizational-project-skill-demand.md
@@ -3,10 +3,10 @@
 Question: How many organizations are using this project and could hire me if I become proficient?
 
 
-## Overview
+### Overview
 The Organization's Project Skill Demand metric is aimed at determining downstream demand of skills related to an open source project. This metric looks at organizations that deploy a project as part of an IT infrastructure, other open source projects with declared dependencies, and references to the project through social media, conference mentions, blog posts, and similar activities. Tracking this metric helps developers identify promising projects for career growth and contributes to project sustainability by indicating community engagement and potential for future development. While this metric doesn't directly address DEI issues, it can indirectly contribute by highlighting projects with diverse communities and inclusive practices.
 
-## Want to Know More?
+### Want to Know More?
 
 <span markdown="1"><details>
 <summary>Click to read more about this metric.</summary>
@@ -47,7 +47,7 @@ StackOverview publishes an annual developer's survey
 
 </details></span>
 
-## References
+### References
 - [Open Source Sponsors][l1]
 - [Fiscal Sponsors and Open Source][l2]
 - [Large Corporate OpenSource Sponsors][l3]
@@ -64,15 +64,16 @@ StackOverview publishes an annual developer's survey
 [l6]: https://www.thoughtworks.com/radar
 [l7]: https://insights.stackoverflow.com/survey/2019#technology
 
-## Contributors
+### Contributors
 
 * Matt Germonprez
 * Kevin Lumbard
 * Georg Link
 * Peculiar C Umeh
 
-## Additional Information
+### Additional Information
 To edit this metric please [submit a Change Request here]( https://github.com/chaoss/wg-value/blob/main/focus-areas/individual-value/organizational-project-skill-demand.md)
+
 To reference this metric in software or publications please use this stable URL: [https://chaoss.community/?p=3566](https://chaoss.community/?p=3566)
 
 <!-- # For groupings in the knowledge base


### PR DESCRIPTION
Updated the Organizational project skill using the new metrics template.

Observation:
The Augur links here are broken or do not exist anymore:

Augur; Examples are available for multiple repositories:
[Rails](http://augur.osshealth.io/repo/Rails%20(wg-value)/rails/overview)
[Zephyr](http://augur.osshealth.io/repo/Zephyr-RTOS/zephyr/overview)
[CloudStack](http://augur.osshealth.io/repo/Apache%20(wg-value)/cloudstack/overview)

Suggestion:
The link should be replace or remove completely